### PR TITLE
Use package_id to ensure idempotency of pkg install.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,5 +27,6 @@ dmg_package "XQuartz" do
   source node['xquartz']['url']
   checksum node['xquartz']['checksum']
   volumes_dir "XQuartz-#{node['xquartz']['version']}"
+  package_id "org.macosforge.xquartz.pkg"
   type "pkg"
 end


### PR DESCRIPTION
Looks like `XQuartz.app` gets installed to `/Applications/Utilities/XQuartz.app` so the **dmg** provider fails to guard against subsequent installations. Two easy wins would be to:
- set the **destination** attribute to `"/Applications/Utilities"`
- set the **package_id** attribute to `"org.macosforge.xquartz.pkg"`

I went with the latter, but the former is just as valid.

Thanks for this cookbook!
