### PR TITLE
Allow dmg-cookbook v2.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,4 +6,4 @@ description      "Installs XQuartz on Mac OS X 10.8 to provide an X11 server."
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.0.0"
 
-depends "dmg", "~> 1.1"
+depends "dmg", ">= 1.1"


### PR DESCRIPTION
Am I correct that you can't set multiple version constraints like this: `>= 1.1, <= 2.0`?
